### PR TITLE
Fix worker construction

### DIFF
--- a/lib/sidekiq/custom_queue/client_middleware.rb
+++ b/lib/sidekiq/custom_queue/client_middleware.rb
@@ -2,7 +2,7 @@ module Sidekiq
   module CustomQueue
     class ClientMiddleware
       def call(worker_class, msg, queue, _redis_pool)
-        worker = worker_class.constantize
+        worker = worker_class.is_a?(String) ? worker_class.constantize : worker_class
         msg['queue'] = worker.custom_queue(msg).to_s if worker.respond_to?(:custom_queue)
         yield
       end


### PR DESCRIPTION
As documented in [Sidekiq's wiki](https://github.com/mperham/sidekiq/wiki/Middleware#client-side-middleware), _client middleware may receive the class argument as a Class object or a String containing the name of the class_.

So I updated this middleware to handle both cases.
