### PR TITLE
Adapting to support Sidekiq 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ method and put that job in this queue:
 WorkerWithCustomQueue.perform_async('xyz', 1) # gets enqueued in the 'xyz_queue' instead of the default queue
 ```
 
+*NOTE:* Although the queue name is created dynamically through the custom method, the Sidekiq Fetcher will still look for such queues from your configuration. So you need to be sure thhe queue names being created are being watched for execution.
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests.

--- a/lib/sidekiq/custom_queue.rb
+++ b/lib/sidekiq/custom_queue.rb
@@ -12,9 +12,3 @@ Sidekiq.configure_client do |config|
     chain.add Sidekiq::CustomQueue::ClientMiddleware
   end
 end
-
-Sidekiq.configure_server do |config|
-  config.client_middleware do |chain|
-    chain.add Sidekiq::CustomQueue::ClientMiddleware
-  end
-end

--- a/lib/sidekiq/custom_queue/client_middleware.rb
+++ b/lib/sidekiq/custom_queue/client_middleware.rb
@@ -1,9 +1,12 @@
 module Sidekiq
   module CustomQueue
     class ClientMiddleware
-      def call(worker_class, msg, queue, _redis_pool)
+      def call(worker_class, msg, _queue, _redis_pool)
         worker = worker_class.constantize
-        msg['queue'] = worker.custom_queue(msg).to_s if worker.respond_to?(:custom_queue)
+        worker = msg['wrapped'].constantize if msg['wrapped'].present?
+        if worker.respond_to?(:custom_queue)
+          msg['queue'] = worker.custom_queue(msg).to_s
+        end
         yield
       end
     end

--- a/sidekiq-custom-queue.gemspec
+++ b/sidekiq-custom-queue.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'sidekiq', '~> 3'
+  spec.add_dependency 'sidekiq', '~> 5'
 
   spec.add_development_dependency 'bundler', '~> 1.10'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
Just a small change to work with Sidekiq 5.x

Note to see that the ServerMiddleware was no longer compatible with Sidekiq interface and also not needed.